### PR TITLE
fix(notify): header must be utf-8 encoded

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Extract version from Github Ref
+      id: extract_version
+      run: |
+        echo VERSION=$(echo ${{ github.ref }} | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+") >> $GITHUB_ENV
+
     - name: Login to DockerHub
       uses: docker/login-action@v2
       with:
@@ -35,7 +40,7 @@ jobs:
         file: Dockerfile
         push: true
         platforms: linux/amd64
-        tags: ghcr.io/antonengelhardt/kicktipp-bot:${{ github.ref }}-amd64
+        tags: ghcr.io/antonengelhardt/kicktipp-bot:${{ env.VERSION }}-amd64
 
     # - name: Build and push arm64 Docker image
     #   uses: docker/build-push-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
         file: Dockerfile
         push: true
         platforms: linux/amd64
-        tags: ghcr.io/antonengelhardt/kicktipp-bot:${{ github.event.number }}-amd64
+        tags: ghcr.io/antonengelhardt/kicktipp-bot:pr-${{ github.event.number }}-amd64
 
     # - name: Build and push arm64 Docker image
     #   uses: docker/build-push-action@v2

--- a/main.py
+++ b/main.py
@@ -229,6 +229,9 @@ def send_ntfy_notification(time, home_team, away_team, quotes, tip):
                 "X-Title": f"{home_team} - {away_team} tipped {tip[0]}:{tip[1]}",
             }
 
+            # utf-8 encode headers
+            headers = {k: v.encode('utf-8') for k, v in headers.items()}
+
             requests.post(NTFY_URL, auth=(
                 NTFY_USERNAME, NTFY_PASSWORD), data=data, headers=headers)
 


### PR DESCRIPTION
## What are the changes?

- the ntfy header must be utf-8 encoded
- extract the tag name from the github ref during release ci
- prefix docker image with `pr-` during tests ci

## How to test the changes?

- see screenshot

## Is this a breaking change?

no

## Additional information

before

![Screenshot-Arc-007561](https://github.com/antonengelhardt/kicktipp-bot/assets/106314688/61e17afe-6aa9-45e0-9345-4303fb84fb88)

after

![Screenshot-Arc-007565](https://github.com/antonengelhardt/kicktipp-bot/assets/106314688/ba0d8335-2ffa-4a29-b296-6eb8f857d353)


