### PR TITLE
fix/docs: comment out `CHROMEDRIVER_PATH` from `.env.example` and add python commands to readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ KICKTIPP_RUN_EVERY_X_MINUTES=20
 
 ZAPIER_URL=https://hooks.zapier.com/hooks/catch/12345678/abcdefgh/
 
-CHROMEDRIVER_PATH=/usr/bin/chromedriver
+# CHROMEDRIVER_PATH=/usr/bin/chromedriver # uncomment this if you run without docker and encounter problems with the driver
 
 NTFY_URL=https://ntfy.your-domain.com/kicktipp-bot
 NTFY_USERNAME=your-username

--- a/README.md
+++ b/README.md
@@ -6,7 +6,24 @@ This script can automatically enter tips into Kicktipp based on the quotes of th
 
 Copy the contents of the `.env.example` file into a new file called `.env` and fill in the values.
 
-Execute the commands below in the `Terminal`-Program. Pre-requisites are `Python`, `pip` and `Docker`.
+### Python
+
+If you use the [fish shell](https://fishshell.com/), you can use the `envsource .env` command, from [this GitHub Gist](https://gist.github.com/nikoheikkila/dd4357a178c8679411566ba2ca280fcc) to load the environment variables.
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the script
+python main.py
+
+# Headless mode
+python main.py --headless
+```
+
+### Docker
+
+Install Docker and run the following commands.
 
 ```bash
 # Get Image


### PR DESCRIPTION
## What are the changes?

- the `CHROMEDRIVER_PATH` environment is not working with docker, so it is commented out now
- added commands to run the script with python commands in GUI mode or headless mode

## How to test the changes?

- Clone repo, run commands

## Is this a breaking change?

no

## Additional information

For #28 
