### PR TITLE
Push PRs only when from same repo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       with:
         context: .
         file: docker/Dockerfile
-        push: true
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         platforms: linux/amd64
         tags: ghcr.io/antonengelhardt/kicktipp-bot:pr-${{ github.event.number }}-amd64
 


### PR DESCRIPTION
## What are the changes?

- disable pushing to Github Docker Repo when PR is coming from another user's repo

## Is this a breaking change?

yes as no images will be pushed

## Additional information

