### PR TITLE
fix(ci): make PR push workflow independent of repo name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
         file: docker/Dockerfile
         push: true
         platforms: linux/amd64
-        tags: ghcr.io/antonengelhardt/kicktipp-bot:pr-${{ github.event.number }}-amd64
+        tags: ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}-amd64
 
     # - name: Build and push arm64 Docker image
     #   uses: docker/build-push-action@v2


### PR DESCRIPTION
## What are the changes?

- make repo name dynamic for the PR push workflow (in tests.yaml)

## How to test the changes?

- Have a look here: https://github.com/totti4ever/kicktipp-bot/actions/runs/17218612113/job/48848307352

## Is this a breaking change?

no

## Additional information
you could possibly check the other two files as well; I only edited the PR file as I don't plan to use the other two