### PR TITLE
Prevent draw tips for no-draw knockout sections

### DIFF
--- a/src/kicktipp_bot/core/game_tipper.py
+++ b/src/kicktipp_bot/core/game_tipper.py
@@ -251,7 +251,22 @@ class GameTipper:
 
             # Create game and calculate tip
             game = Game(home_team, away_team, quotes, game_time)
+            section = GameDataExtractor.extract_game_section(data_row)
+            draws_allowed = not GameDataExtractor.section_disallows_draw(
+                section)
             tip = game.calculate_tip()
+            original_tip = tip
+
+            if not draws_allowed:
+                tip = game.resolve_draw_tip(tip)
+                if tip != original_tip:
+                    logger.info(
+                        "Adjusted no-draw tip for "
+                        f"{home_team} vs {away_team} "
+                        f"({section or 'unknown section'}): "
+                        f"{original_tip[0]} - {original_tip[1]} -> "
+                        f"{tip[0]} - {tip[1]}")
+
             logger.info(f"Calculated tip: {tip[0]} - {tip[1]}")
 
             # Enter tip and send notifications
@@ -346,6 +361,7 @@ class GameTipper:
 
         # Try regular click first
         if SeleniumUtils.safe_click(submit_button, "submit button"):
+            self._validate_submission_result()
             logger.info("Tips form submitted successfully")
         else:
             # Fallback to JavaScript click
@@ -353,10 +369,59 @@ class GameTipper:
             try:
                 self.driver.execute_script(
                     "arguments[0].click();", submit_button)
+                self._validate_submission_result()
                 logger.info("Tips form submitted successfully via JavaScript")
+            except GameTippingError:
+                raise
             except Exception as e:
                 logger.error(f"Both regular and JavaScript clicks failed: {e}")
                 raise GameTippingError("Failed to submit tips form")
+
+    def _validate_submission_result(self) -> None:
+        """Detect known Kicktipp validation errors after submitting tips."""
+        sleep(1)
+        feedback_text = self._get_submission_feedback_text()
+        if self._contains_submission_error(feedback_text):
+            raise GameTippingError(
+                "Kicktipp rejected submitted tips: draw is not possible for "
+                "at least one selected game section")
+
+    def _get_submission_feedback_text(self) -> str:
+        """Collect visible page and alert text after form submission."""
+        feedback_parts = []
+
+        try:
+            alert = self.driver.switch_to.alert
+            alert_text = alert.text
+            if alert_text:
+                feedback_parts.append(alert_text)
+        except WebDriverException:
+            pass
+
+        try:
+            body = self.driver.find_element(By.TAG_NAME, "body")
+            body_text = SeleniumUtils.safe_get_text(
+                body, "submission page body")
+            if body_text:
+                feedback_parts.append(body_text)
+        except WebDriverException as e:
+            logger.debug(f"Could not read submission page body: {e}")
+
+        return "\n".join(feedback_parts)
+
+    @staticmethod
+    def _contains_submission_error(text: str) -> bool:
+        """Return True if submitted tips were rejected by Kicktipp."""
+        normalized = text.casefold()
+        normalized = normalized.replace("\u00f6", "oe")
+
+        return (
+            "nicht alle gesendeten tipps waren korrekt" in normalized or
+            (
+                "unentschieden" in normalized and
+                ("nicht moeglich" in normalized or "nicht moglich" in normalized)
+            )
+        )
 
     def _is_debug_mode(self) -> bool:
         """Check if running in debug mode."""

--- a/src/kicktipp_bot/core/table_processors.py
+++ b/src/kicktipp_bot/core/table_processors.py
@@ -1,12 +1,14 @@
 """Table processing utilities for game tipping."""
 
 import logging
+import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from typing import Optional
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.common.exceptions import WebDriverException
 
 from ..utils.selenium_utils import SeleniumUtils
 
@@ -155,6 +157,7 @@ class GameDataExtractor:
     # XPath selectors for quote extraction
     XPATH_QUOTE_ANCHOR = './/a[contains(@class, "quote")]'
     XPATH_QUOTE_SPAN = ".//span[contains(@class, 'quote')][span[contains(@class,'quote-label')] and span[contains(@class,'quote-text')]]"
+    GAME_SECTION_SELECTOR = '.kicktipp-spielabschnitt-markierung'
 
     @staticmethod
     def extract_team_name(data_row, column_index: int, team_type: str) -> Optional[str]:
@@ -188,6 +191,106 @@ class GameDataExtractor:
                     logger.debug(
                         f"Game is over or not available: {result_text}")
             return None
+
+    @staticmethod
+    def extract_game_section(game_row) -> Optional[str]:
+        """Extract the Kicktipp game section marker from a game row."""
+        section_parts = []
+
+        try:
+            section_elements = game_row.find_elements(
+                By.CSS_SELECTOR, GameDataExtractor.GAME_SECTION_SELECTOR)
+        except WebDriverException as e:
+            logger.debug(f"Could not inspect game section marker: {e}")
+            section_elements = []
+
+        for section_element in section_elements:
+            section_text = GameDataExtractor._extract_section_element_text(
+                section_element)
+            if section_text:
+                section_parts.append(section_text)
+
+        section = " ".join(section_parts).strip()
+        if section:
+            logger.debug(f"Found game section marker: '{section}'")
+            return section
+
+        fallback_section = GameDataExtractor._extract_game_section_fallback(
+            game_row)
+        if fallback_section:
+            logger.debug(
+                f"Detected game section marker via fallback text: '{fallback_section}'")
+            return fallback_section
+
+        return None
+
+    @staticmethod
+    def section_disallows_draw(section: Optional[str]) -> bool:
+        """Return True if a Kicktipp game section does not allow draws."""
+        if not section:
+            return False
+
+        normalized = GameDataExtractor._normalize_game_section(section)
+        return (
+            "n.e" in normalized or
+            "a.pso" in normalized or
+            "apso" in normalized or
+            "elfmeterschiessen" in normalized or
+            "penalt" in normalized
+        )
+
+    @staticmethod
+    def _extract_section_element_text(section_element) -> Optional[str]:
+        parts = []
+
+        text = SeleniumUtils.safe_get_text(
+            section_element, 'game section marker')
+        if text:
+            parts.append(text)
+
+        for attribute in ('title', 'aria-label', 'value'):
+            value = SeleniumUtils.safe_get_attribute(
+                section_element, attribute, 'game section marker')
+            if value:
+                parts.append(value)
+
+        section_text = " ".join(parts).strip()
+        return section_text or None
+
+    @staticmethod
+    def _extract_game_section_fallback(game_row) -> Optional[str]:
+        fallback_parts = []
+
+        row_text = SeleniumUtils.safe_get_text(
+            game_row, 'game row section fallback')
+        if row_text:
+            fallback_parts.append(row_text)
+
+        for attribute in ('title', 'aria-label', 'value'):
+            value = SeleniumUtils.safe_get_attribute(
+                game_row, attribute, 'game row section fallback')
+            if value:
+                fallback_parts.append(value)
+
+        fallback_text = " ".join(fallback_parts).strip()
+        if GameDataExtractor.section_disallows_draw(fallback_text):
+            return fallback_text
+
+        return None
+
+    @staticmethod
+    def _normalize_game_section(section: str) -> str:
+        normalized = section.casefold()
+        replacements = {
+            "\u00e4": "ae",
+            "\u00f6": "oe",
+            "\u00fc": "ue",
+            "\u00df": "ss",
+        }
+        for original, replacement in replacements.items():
+            normalized = normalized.replace(original, replacement)
+
+        return re.sub(r"\s+", "", normalized)
 
     @staticmethod
     def extract_quotes(game_row) -> Optional[list]:

--- a/src/kicktipp_bot/models/game.py
+++ b/src/kicktipp_bot/models/game.py
@@ -43,13 +43,19 @@ class Game:
         except (ValueError, TypeError) as e:
             raise ValueError(f"Invalid quote values: {quotes}") from e
 
-    def calculate_tip(self, home_quote: Union[float, None] = None, away_quote: Union[float, None] = None) -> Tuple[int, int]:
+    def calculate_tip(
+        self,
+        home_quote: Union[float, None] = None,
+        away_quote: Union[float, None] = None,
+        allow_draw: bool = True
+    ) -> Tuple[int, int]:
         """
         Calculate betting tip based on the quotes.
 
         Args:
             home_quote: Quote for home team win (uses self._validated_quotes[0] if None)
             away_quote: Quote for away team win (uses self._validated_quotes[2] if None)
+            allow_draw: Whether equal-score predictions are valid
 
         Returns:
             Tuple of (home_goals, away_goals) prediction
@@ -72,19 +78,44 @@ class Game:
         # Calculate tips based on quote difference
         if abs(quote_difference) < 0.25:
             # Very close match - predict draw-like result
-            return random_goal, random_goal
+            tip = (random_goal, random_goal)
         elif quote_difference < 0:
             # Home team favored
             home_goals = max(
                 0, round(-quote_difference * coefficient)) + random_goal
             away_goals = random_goal
-            return home_goals, away_goals
+            tip = (home_goals, away_goals)
         else:
             # Away team favored
             home_goals = random_goal
             away_goals = max(
                 0, round(quote_difference * coefficient)) + random_goal
-            return home_goals, away_goals
+            tip = (home_goals, away_goals)
+
+        if not allow_draw:
+            return self.resolve_draw_tip(tip, home_quote, away_quote)
+
+        return tip
+
+    def resolve_draw_tip(
+        self,
+        tip: Tuple[int, int],
+        home_quote: Union[float, None] = None,
+        away_quote: Union[float, None] = None
+    ) -> Tuple[int, int]:
+        """Resolve a draw prediction into a one-goal win based on win quotes."""
+        if tip[0] != tip[1]:
+            return tip
+
+        if home_quote is None:
+            home_quote = self._validated_quotes[0]
+        if away_quote is None:
+            away_quote = self._validated_quotes[2]
+
+        if home_quote <= away_quote:
+            return tip[0] + 1, tip[1]
+
+        return tip[0], tip[1] + 1
 
     def __str__(self) -> str:
         """String representation of the game."""


### PR DESCRIPTION
## What are the changes?

- Detect Kicktipp game section markers where draws are not allowed, such as `n.E.` and penalty shootout sections.
- Resolve calculated draw tips for those sections into a one-goal win based on the lower winning quote.
- Validate the submission result after sending tips and raise a `GameTippingError` when Kicktipp rejects invalid draw submissions.

## How to test the changes?

- Ran `python -m py_compile src/kicktipp_bot/core/game_tipper.py src/kicktipp_bot/core/table_processors.py src/kicktipp_bot/models/game.py`

## Is this a breaking change?

No.

## Additional information

Closes #80

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the bot from submitting draw tips in knockout sections (e.g. `n.E.`, penalty shootout) by detecting the Kicktipp game-section marker on each row and resolving any equal-score prediction into a one-goal win for the more likely team. A post-submission validation step is also added to raise `GameTippingError` when Kicktipp returns a rejection message.

- `table_processors.py` gains `extract_game_section` (with a CSS-selector primary path and a full-row-text fallback) and `section_disallows_draw` with umlaut-aware normalization.
- `game.py` extracts `resolve_draw_tip` as a public helper and adds an `allow_draw` parameter to `calculate_tip`, though the calling code in `game_tipper.py` bypasses that parameter and calls `resolve_draw_tip` directly.
- `game_tipper.py` calls `_validate_submission_result` after both click paths, reading any JS alert and the page body for known German rejection strings.

<h3>Confidence Score: 3/5</h3>

The draw-detection and section-normalization logic is correct, but the JS alert is read without being dismissed, which can leave the browser in a broken state for the rest of the session.

The core no-draw logic is well-implemented. The main concern is in _get_submission_feedback_text: if Kicktipp ever presents a JS alert that does not match the error patterns, the alert stays open and every subsequent driver call in that session will fail.

src/kicktipp_bot/core/game_tipper.py — specifically the alert handling in _get_submission_feedback_text

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/kicktipp_bot/core/game_tipper.py | Adds section detection before tip calculation and post-processes draw tips for no-draw sections; adds _validate_submission_result to detect Kicktipp rejection after form submit — alert is read but never dismissed, risking a stuck browser session. |
| src/kicktipp_bot/core/table_processors.py | Adds extract_game_section and section_disallows_draw with a fallback text scan and umlaut normalization; logic is sound and well-guarded with WebDriverException handling. |
| src/kicktipp_bot/models/game.py | Extracts resolve_draw_tip as a public method and adds an allow_draw parameter to calculate_tip; the new parameter is never used by the caller, leaving it as dead code. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Process game row] --> B[extract_game_section]
    B --> C{section_disallows_draw?}
    C -- No --> D[calculate_tip allow_draw=True]
    C -- Yes --> E[calculate_tip allow_draw=True]
    E --> F[resolve_draw_tip lowest quote wins]
    D --> G[Enter tip into form]
    F --> G
    G --> H[Submit form]
    H --> I[_validate_submission_result sleep 1s]
    I --> J[_get_submission_feedback_text read alert + body]
    J --> K{_contains_submission_error?}
    K -- Yes --> L[raise GameTippingError]
    K -- No --> M[Success]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Process game row] --> B[extract_game_section]
    B --> C{section_disallows_draw?}
    C -- No --> D[calculate_tip allow_draw=True]
    C -- Yes --> E[calculate_tip allow_draw=True]
    E --> F[resolve_draw_tip lowest quote wins]
    D --> G[Enter tip into form]
    F --> G
    G --> H[Submit form]
    H --> I[_validate_submission_result sleep 1s]
    I --> J[_get_submission_feedback_text read alert + body]
    J --> K{_contains_submission_error?}
    K -- Yes --> L[raise GameTippingError]
    K -- No --> M[Success]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Prevent draw tips for penalty shootout s..."](https://github.com/antonengelhardt/kicktipp-bot/commit/147e2a97b8b3afa7925c1014414115075117f603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42970184)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->