### PR TITLE
Remove cluster rollout from CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,25 +36,3 @@ jobs:
         push: ${{ github.event.repository.full_name == github.repository }}
         platforms: linux/amd64
         tags: ghcr.io/antonengelhardt/kicktipp-bot:amd64
-
-    # - name: Build and push arm64 Docker image
-    #   uses: docker/build-push-action@v2
-    #   with:
-    #     context: .
-    #     file: docker/Dockerfile
-    #     push: true
-    #     platforms: linux/arm64
-    #     tags: ghcr.io/antonengelhardt/kicktipp-bot:arm64
-
-  deploy-to-kubernetes:
-    name: Deploy to Kubernetes
-    runs-on: ubuntu-latest
-    if: ${{ github.event.repository.full_name == github.repository }}
-    needs: push
-    steps:
-    - name: Deploy to Kubernetes
-      uses: actions-hub/kubectl@master
-      env:
-        KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-      with:
-        args: rollout restart deployment kicktipp-bot -n kicktipp-bot


### PR DESCRIPTION
## Summary
- Drop `kubectl rollout` / `KUBE_CONFIG` from GitHub Actions. CI only builds and pushes the image.
- ae-k8s-04 Flux image automation watches GHCR and commits `tag@digest` so pods roll there.


## After merge
Delete the unused Actions secret:

```bash
gh secret delete KUBE_CONFIG -R antonengelhardt/kicktipp-bot
```

## Test plan
- [ ] Workflow still builds and pushes on merge to the default branch
- [ ] No remaining `kubectl` / `KUBE_CONFIG` references in `.github/workflows`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the GitHub Actions Kubernetes rollout job and its `KUBE_CONFIG` dependency, leaving the workflow responsible only for building and publishing the `amd64` container image.
- Deployment rollout ownership moves to external Flux image automation.
- No remaining repository-local workflow dependency on the deleted job was identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because image publication remains intact and the removed deployment job has no repository-local dependents.

No actionable failure is established by the change; successful rollout now depends on the external Flux automation described as the intended deployment owner.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/main.yaml | Cleanly removes the Kubernetes deployment job while preserving the existing image build-and-push job. |

<sub>Reviews (1): Last reviewed commit: ["Stop rolling out from Actions; Flux on a..."](https://github.com/antonengelhardt/kicktipp-bot/commit/bc094e1dfcf46a850f5f14d35d9fb9b4887d342e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60727851)</sub>

<!-- /greptile_comment -->