### PR TITLE
Reap Chromium zombie processes after Selenium quit

### DIFF
--- a/src/kicktipp_bot/main.py
+++ b/src/kicktipp_bot/main.py
@@ -18,6 +18,7 @@ from .core.authentication import Authenticator, AuthenticationError
 from .core.game_tipper import GameTipper, GameTippingError
 from .core.notifications import NotificationManager
 from .health import health_status, health_monitor
+from .utils.process import reap_zombie_children
 
 
 def setup_logging(debug_mode: bool = False) -> None:
@@ -103,6 +104,9 @@ class KicktippBot:
                 logger.info("WebDriver closed successfully")
             except Exception as e:
                 logger.warning(f"Error closing WebDriver: {e}")
+            finally:
+                self.driver = None
+        reap_zombie_children()
 
 
 def run_bot() -> None:
@@ -191,6 +195,7 @@ def main() -> None:
             while (remaining := next_run - datetime.now().timestamp()) > 0:
                 # Send heartbeat every 10 seconds during sleep to keep health check happy
                 health_status.heartbeat()
+                reap_zombie_children()
                 sleep(min(10, remaining))
 
     except KeyboardInterrupt:

--- a/src/kicktipp_bot/main.py
+++ b/src/kicktipp_bot/main.py
@@ -103,7 +103,7 @@ class KicktippBot:
                 self.driver.quit()
                 logger.info("WebDriver closed successfully")
             except Exception as e:
-                logger.warning(f"Error closing WebDriver: {e}")
+                logger.warning(f"Error closing WebDriver: {e}", exc_info=True)
             finally:
                 self.driver = None
         reap_zombie_children()

--- a/src/kicktipp_bot/utils/process.py
+++ b/src/kicktipp_bot/utils/process.py
@@ -18,6 +18,8 @@ def reap_zombie_children() -> int:
             pid, _status = os.waitpid(-1, os.WNOHANG)
         except ChildProcessError:
             break
+        except InterruptedError:
+            continue
         if pid == 0:
             break
         reaped += 1

--- a/src/kicktipp_bot/utils/process.py
+++ b/src/kicktipp_bot/utils/process.py
@@ -1,0 +1,26 @@
+"""Helpers for leftover child processes (e.g. Chromium after Selenium quit)."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def reap_zombie_children() -> int:
+    """Collect exited children so they do not stay as zombies.
+
+    Selenium's driver.quit() stops Chrome but often leaves helper processes
+    (crashpad, zygote) as zombies when this app is PID 1 in a container.
+    """
+    reaped = 0
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+        if pid == 0:
+            break
+        reaped += 1
+    if reaped:
+        logger.info("Reaped %s leftover child process(es)", reaped)
+    return reaped

--- a/src/kicktipp_bot/webdriver/webdriver_manager.py
+++ b/src/kicktipp_bot/webdriver/webdriver_manager.py
@@ -47,5 +47,8 @@ class WebDriverManager:
         chrome_options.add_argument("--disable-application-cache")
         chrome_options.add_argument("--disable-gpu")
         chrome_options.add_argument("--disable-setuid-sandbox")
+        # Crashpad/breakpad helpers often become zombies after driver.quit()
+        chrome_options.add_argument("--disable-crash-reporter")
+        chrome_options.add_argument("--disable-breakpad")
 
         return chrome_options


### PR DESCRIPTION
## Summary
- Reap leftover child processes after `driver.quit()` and during the sleep loop. In the container the bot is PID 1, so Chromium crashpad/breakpad helpers stay as zombies.
- Disable Chrome crash reporter / breakpad in headless mode so fewer of those helpers start.

## Test plan
- [ ] Image builds
- [ ] One tipping cycle + sleep: `ps` in the pod does not accumulate `<defunct>` Chromium helpers
- [ ] `/health` stays healthy across the 30-minute interval


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mitigates accumulation of defunct Chromium helper processes when the bot runs as PID 1 in its container.
- Adds a non-blocking helper that reaps exited child processes.
- Reaps children after WebDriver cleanup and periodically during the sleep interval.
- Disables Chromium crash-reporting helpers in headless mode to reduce the processes requiring cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

The reaper runs after Selenium shutdown and throughout the sleep interval, while the new Chromium flags are restricted to the intended headless path; repository context shows no competing child-process owner whose exit status could be consumed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/kicktipp_bot/main.py | Integrates child-process reaping into WebDriver cleanup and the recurring sleep loop without disrupting the existing lifecycle. |
| src/kicktipp_bot/utils/process.py | Adds a bounded, non-blocking `waitpid` loop that collects all currently exited child processes. |
| src/kicktipp_bot/webdriver/webdriver_manager.py | Disables Chromium crash reporter and breakpad helpers only for the headless browser configuration. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run tipping cycle] --> B[Create headless Chromium driver]
    B --> C[Perform authentication and tipping]
    C --> D[WebDriver cleanup]
    D --> E[driver.quit]
    E --> F[Reap exited child processes]
    F --> G[Enter scheduled sleep loop]
    G --> H[Health heartbeat]
    H --> I[Reap newly exited children]
    I --> J[Sleep up to 10 seconds]
    J --> G
```

<sub>Reviews (1): Last reviewed commit: ["fix: reap Chromium helper zombies after ..."](https://github.com/antonengelhardt/kicktipp-bot/commit/923781e5b0bb7227e235ba756ed58ad4d4b20f76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60777006)</sub>

<!-- /greptile_comment -->