### PR TITLE
Enable weekly Dependabot version updates for pip, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
+    labels:
+      - "dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    reviewers:
+      - "antonengelhardt"
+    commit-message:
+      prefix: "chore(deps): "
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "antonengelhardt"
+    commit-message:
+      prefix: "chore(deps): "
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "antonengelhardt"
     commit-message:
       prefix: "chore(deps): "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     reviewers:
       - "antonengelhardt"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore(deps)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -21,7 +21,7 @@ updates:
     reviewers:
       - "antonengelhardt"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore(deps)"
 
   - package-ecosystem: "docker"
     directory: "/docker"
@@ -32,4 +32,4 @@ updates:
     reviewers:
       - "antonengelhardt"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore(deps)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-selenium>=4.21.0
-requests>=2.25.1
-sentry_sdk>=2.35.0
+# Pin exact versions so Docker/local installs stay reproducible and Dependabot can bump them.
+selenium==4.49.0
+requests==2.34.2
+sentry-sdk==2.69.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What are the changes?

- Replace the unused pip-only daily `.github/dependabot.yml` with weekly `pip`, `github-actions`, and `docker` updates, matching wasm-oidc-plugin / basic-auth-plugin.
- Reviewer is `antonengelhardt`, PRs are labeled `dependencies`, and commits use the `chore(deps): ` prefix.
- Docker ecosystem directory is `/docker` so Dependabot watches `docker/Dockerfile` (`FROM python:3.10.21-alpine`). `docker/Dockerfile.dep` is ignored.
- Pin `requirements.txt` to current latest exact versions so Docker/local installs are reproducible and Dependabot has a baseline to bump:
  - `selenium==4.49.0`
  - `requests==2.34.2`
  - `sentry-sdk==2.69.1` (canonical PyPI name)
- Pip patches are not ignored. No lockfile was added.

## How to test the changes?

- After merge, confirm Dependabot opens version-update PRs for outdated pip packages, GitHub Actions (`docker/*-action@v2`, `actions/checkout@v4`), and the Python Alpine base image.
- The `dependencies` label does not exist yet; Dependabot creates it when it opens the first update PR.
- `pip install -r requirements.txt` resolves the three pinned packages (verified with `--dry-run`).

## Is this a breaking change?

no — builds already floated to latest under the old `>=` pins. Exact pins make that version set explicit.

## Additional information

Repo **Settings → Code security → Dependabot version updates** must be enabled if the existing yaml never produced bot PRs. `dependabot[bot]` has never opened a commit/PR here, so the 2023 pip-only file was not actually doing work. Renovate was not installed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09496-8857-7231-b87c-8e8de85643b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09496-8857-7231-b87c-8e8de85643b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63385118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The Dependabot configuration appears safe to merge.

<h3>Summary</h3>

- Changes pip updates from daily to weekly.
- Adds weekly GitHub Actions and Docker update configurations.
- Applies dependency labels, reviewer assignment, and conventional commit prefixes.

<sub>Reviews (1) · Last reviewed commit: ["chore(deps): expand Dependabot to pip, A..."](https://github.com/antonengelhardt/kicktipp-bot/commit/1b38603e8d02838f48f16979ab66bf451bed2fc8)</sub>

<!-- /greptile_comment -->